### PR TITLE
Empty query

### DIFF
--- a/papis-rofi/papis_rofi/main.py
+++ b/papis-rofi/papis_rofi/main.py
@@ -209,7 +209,7 @@ class Gui(object):
 
 
 @click.command()
-@click.argument('query', nargs=1)
+@click.argument('query', nargs=1, default='')
 @click.help_option('--help', '-h')
 @click.version_option(version=papis_rofi.__version__)
 def main(query):


### PR DESCRIPTION
With this PR it is now possible to launch papis-rofi without a query and access the entire catalog. This was advertised as possible in the README but was actually forbidden by `click`.